### PR TITLE
Sending multiple requests

### DIFF
--- a/front-end/src/view/components/project/ProjectAssign.tsx
+++ b/front-end/src/view/components/project/ProjectAssign.tsx
@@ -34,11 +34,11 @@ export default function ProjectAssign() {
   const showAssignedImages = (images: Image[], role: string) => {
     if (role === 'annotate') {
       images.forEach(async (image: Image) => {
-        await updateToAnnotate({ user: image.idAnnotator, image: image.id, data: image.data });
+        updateToAnnotate({ user: image.idAnnotator, image: image.id, data: image.data });
       });
     } else {
       images.forEach(async (image: Image) => {
-        await updateToVerify({ user: image.idVerifier, image: image.id, data: image.data });
+        updateToVerify({ user: image.idVerifier, image: image.id, data: image.data });
       });
     }
   };
@@ -88,14 +88,16 @@ export default function ProjectAssign() {
     }
   };
 
-  const handleSubmit = () => {
-    toAnnotate.forEach((e) => {
-      assignAnnotatorToImage(e.image, e.user, project?.id || '');
-    });
+  const handleSubmit = async () => {
+    for (let i = 0; i < toAnnotate.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await assignAnnotatorToImage(toAnnotate[i].image, toAnnotate[i].user, project?.id || '');
+    }
 
-    toVerify.forEach((e) => {
-      assignVerifierToImage(e.image, e.user, project?.id || '');
-    });
+    for (let i = 0; i < toVerify.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await assignVerifierToImage(toVerify[i].image, toVerify[i].user, project?.id || '');
+    }
 
     navigate(Paths.Projects);
   };

--- a/front-end/src/view/components/project/index.tsx
+++ b/front-end/src/view/components/project/index.tsx
@@ -12,10 +12,14 @@ export default function ProjectEdit() {
   let empty = document.getElementById('empty');
 
   const project = useData(async () => findProjectById(idProject ?? ''));
-  const handleUpload = () => {
+  const handleUpload = async () => {
     if (!idProject) throw Error('no project id!');
-    console.log(FILES);
-    Object.values(FILES).forEach((file) => addImageToProject(file, idProject));
+
+    const files = Object.values(FILES);
+    for (let i = 0; i < files.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await addImageToProject(files[i], idProject);
+    }
   };
 
   console.log(project);


### PR DESCRIPTION
The problem was that forEach calls don't wait for one another.
Traditional for loop calls do.
ESLint [recommends](https://eslint.org/docs/rules/no-await-in-loop) turning this setting off in such cases

@screensoftware you mentioned the ESLint rule, I think you might want to take a look at this.