### PR TITLE
Disable statistics on project cards

### DIFF
--- a/front-end/src/view/components/projects/Card.tsx
+++ b/front-end/src/view/components/projects/Card.tsx
@@ -13,14 +13,14 @@ import OptionsIcon from '../../../assets/icons/options.svg';
 
 import Dropdown from './Dropdown';
 import useData from '../../../data/hooks';
-import { calculateTotalCost, percentageOfImagesDone } from '../../../data/financier';
+// import { percentageOfImagesDone } from '../../../data/financier';
 
 const Card = (props: any) => {
   const { project, options }: { project: Project, options: any} = props;
   const [user] = useUserData();
   const navigate = useNavigate();
-  const totalSpending = useData(async () => calculateTotalCost(project.id));
-  const percentage = useData(async () => percentageOfImagesDone(project.id));
+  const totalSpending = useData(async () => [8] /* calculateTotalCost(project.id) */);
+  const percentage = useData(async () => [4] /* percentageOfImagesDone(project.id) */);
   if (!totalSpending || percentage === null) return null;
 
   const cardClickHandler = () => {


### PR DESCRIPTION
Calling the finance functions causes a lot of CORS errors to be thrown and makes testing the rest of the software very hard. I'm disabling those functions in the project cards temporarily until we solve that issue.

@LauraAmabili you'll want to know about this change.

