### PR TITLE
Monthly work tracking

### DIFF
--- a/front-end/src/data/authenticator.ts
+++ b/front-end/src/data/authenticator.ts
@@ -114,6 +114,7 @@ export async function signUp(name: string, email: string, password: string, role
       metadata: {
         fullname: name,
         projects: {},
+        workDoneInTime: {},
       },
     }, (error, response) => {
       if (error) {

--- a/front-end/src/data/projects.ts
+++ b/front-end/src/data/projects.ts
@@ -61,6 +61,7 @@ export async function createProject(
     pricePerImageVerification: financialModel.pricePerImageVerification,
     hourlyRateAnnotation: financialModel.hourlyRateAnnotation,
     hourlyRateVerification: financialModel.hourlyRateVerification,
+    workDoneInTime: {},
     images: { // A newly created project has no images.
       needsAnnotatorAssignment: [],
       needsVerifierAssignment: [],

--- a/front-end/src/data/types.ts
+++ b/front-end/src/data/types.ts
@@ -1,3 +1,5 @@
+export type YearMonthDay<T> = { [year: string]: { [month: string]: { [day: string]: T } } };
+
 export type UserID = string;
 export type Role = 'projectManager' | 'annotator' | 'verifier' | 'finance';
 export type User = {
@@ -11,8 +13,14 @@ export type User = {
             waitingForVerification: ImageID[], // used when the annotation is rejected and annotated again and 
                                             // when the annotation is annotated for the first time and is not verified yet.
             verified: { imageID: ImageID, date: Date}[]
-        }
+        },
     },
+    workDoneInTime: YearMonthDay <{
+        [projectId: ProjectID]: {
+            annotated: ImageID[],
+            verified: ImageID[],
+        }
+    }>
     name: string,
     email: string,
     role: Role,
@@ -34,6 +42,12 @@ export type Project = {
     pricePerImageVerification: number,
     hourlyRateAnnotation: number,
     hourlyRateVerification: number
+
+    workDoneInTime: YearMonthDay <{
+        imageId: ImageID,
+        annotator: UserID,
+        verifier: UserID,
+    }[]>
 
     images: {
         needsAnnotatorAssignment: ImageID[],

--- a/front-end/src/data/users.ts
+++ b/front-end/src/data/users.ts
@@ -28,6 +28,7 @@ export async function findUserById(id: UserID): Promise<User> {
           name: response.fullname,
           role: response.roles[0],
           projects: response.projects,
+          workDoneInTime: response.workDoneInTime,
         };
 
         resolve(user);
@@ -46,6 +47,7 @@ export async function updateUser(user: User): Promise<void> {
       metadata: {
         fullname: user.name,
         projects: user.projects,
+        workDoneInTime: user.workDoneInTime,
       },
     }, (error, response) => {
       if (error) {

--- a/front-end/src/data/verification.test.ts
+++ b/front-end/src/data/verification.test.ts
@@ -1,5 +1,5 @@
 import {
-  addImageToProject, Annotation, createProject, createUser, ImageID, ProjectID, UserID, addUserToProject, findProjectById,
+  addImageToProject, Annotation, createProject, createUser, ImageID, ProjectID, UserID, addUserToProject, findProjectById, findUserById,
 } from '.';
 import {
   saveAnnotation, assignVerifierToImage, assignAnnotatorToImage, getImagesOfUser, findImageById,
@@ -67,4 +67,17 @@ describe('Accept annotated image', () => {
   it('moves the image in done for the project', () => expect(findProjectById(projectId).then((project) => project.images.done.findIndex((image) => image.imageId === imageId))).resolves.toBeGreaterThanOrEqual(0));
   it('moves the image in annotated for the annotator', () => expect(getImagesOfUser(projectId, 'annotated', annotatorId).then((images) => images.findIndex((image) => image.id === imageId))).resolves.toBeGreaterThanOrEqual(0));
   it('moves the image in verified for the verifier', () => expect(getImagesOfUser(projectId, 'verified', verifierId).then((images) => images.findIndex((image) => image.id === imageId))).resolves.toBeGreaterThanOrEqual(0));
+
+  it('correctly modifies all workDoneInTime fields', async () => {
+    const project = await findProjectById(projectId);
+    const annotator = await findUserById(annotatorId);
+    const verifier = await findUserById(verifierId);
+    const now = new Date();
+    const year = now.getFullYear().toString();
+    const month = now.getMonth().toString();
+    const day = now.getDay().toString();
+    expect(project.workDoneInTime[year][month][day]).toContainEqual({ imageId, annotator: annotatorId, verifier: verifierId });
+    expect(annotator.workDoneInTime[year][month][day][projectId].annotated).toContain(imageId);
+    expect(verifier.workDoneInTime[year][month][day][projectId].verified).toContain(imageId);
+  });
 });

--- a/front-end/src/data/verification.ts
+++ b/front-end/src/data/verification.ts
@@ -2,11 +2,10 @@ import {
   ImagesDB, ProjectsDB,
 } from './databases';
 import {
-  ImageID, Annotation, ProjectID, updateUser, findUserById, findProjectById,
+  ImageID, Annotation, ProjectID, updateUser, findUserById, findProjectById, User, Project,
 } from '.';
 import { createRejectedImage } from './rejectedAnnotation';
 import { findImageById } from './images';
-
 /**
  * rejects the annotation done by an annotator:
  * it is expected that later the annotator will correct the annotation
@@ -55,7 +54,7 @@ export async function rejectAnnotation(
 }
 
 /**
- * it move the image in the state of done for the project project
+ * Verifies the annotation associated with an image.
  * @param newAnnotation if not null, the image annotation is modified by the verifier
  */
 export async function verifyImage(
@@ -84,20 +83,15 @@ export async function verifyImage(
   const dateTime = new Date();
   project.images.done.push({ imageId: imageID, doneDate: dateTime });
 
-  await ProjectsDB.put(project);
-
   // for the annotator user, image goes from waitingForVerification to annotated
   annotator.projects[projectID].waitingForVerification.splice(imageIndexAnnotator, 1);
   annotator.projects[projectID].annotated.push({ imageID, date: dateTime });
-  await updateUser(annotator);
 
   // for the verifier user, image goes from toVerify to verified
   verifier.projects[projectID].toVerify.splice(imageIndexVerifier, 1);
-
   verifier.projects[projectID].verified.push({ imageID, date: dateTime });
-  await updateUser(verifier);
 
-  // the image's annotation becomes undefined
+  // the image's annotation may be updated.
   if (newAnnotation) {
     const newImage = {
       ...image,
@@ -105,4 +99,50 @@ export async function verifyImage(
     };
     await ImagesDB.put(newImage);
   }
+
+  // populate the workDoneInTime fields.
+  putWorkDoneInTime(annotator, verifier, project, imageID);
+
+  await ProjectsDB.put(project);
+  await updateUser(annotator);
+  await updateUser(verifier);
+}
+
+/**
+ * Modifies parameters `annotator`, `verifier`, `project` to record that the image was verified on the current date.  
+ * WARNING:  
+ * ! Does not save the objects to the database !  
+ * ! Modifies the passed objects !  
+ */
+function putWorkDoneInTime(annotator:User, verifier: User, project: Project, image: ImageID) {
+  // find the time fields.
+  const now = new Date();
+  const year = now.getFullYear().toString();
+  const month = now.getMonth().toString();
+  const day = now.getDay().toString();
+
+  // handle edge case where one of the fields may not exist.
+  // ! If you know a better way to do this, please tell Cem, he needs help :( ----------------------
+  [annotator, verifier].forEach((user) => {
+    // eslint-disable-next-line no-param-reassign
+    if (!user.workDoneInTime[year]) { user.workDoneInTime[year] = {}; }
+    // eslint-disable-next-line no-param-reassign
+    if (!user.workDoneInTime[year][month]) { user.workDoneInTime[year][month] = {}; }
+    // eslint-disable-next-line no-param-reassign
+    if (!user.workDoneInTime[year][month][day]) { user.workDoneInTime[year][month][day] = {}; }
+    // eslint-disable-next-line no-param-reassign
+    if (!user.workDoneInTime[year][month][day][project.id]) { user.workDoneInTime[year][month][day][project.id] = { annotated: [], verified: [] }; }
+  });
+  // eslint-disable-next-line no-param-reassign
+  if (!project.workDoneInTime[year]) { project.workDoneInTime[year] = {}; }
+  // eslint-disable-next-line no-param-reassign
+  if (!project.workDoneInTime[year][month]) { project.workDoneInTime[year][month] = {}; }
+  // eslint-disable-next-line no-param-reassign
+  if (!project.workDoneInTime[year][month][day]) { project.workDoneInTime[year][month][day] = []; }
+  // ! ---------------------------------------------------------------------------------------------
+
+  // put the new entry in the required fields.
+  annotator.workDoneInTime[year][month][day][project.id].annotated.push(image);
+  verifier.workDoneInTime[year][month][day][project.id].verified.push(image);
+  project.workDoneInTime[year][month][day].push({ annotator: annotator.id, verifier: verifier.id, imageId: image });
 }


### PR DESCRIPTION
This PR adds a new field to `User` and `Project` that helps track work month by month.
It also includes the data tier changes to handle this new bookkeeping and a new test case to make sure it's done correctly.
I plan to use these to be able to implement all reports, graphs and monthly earnings more efficiently.
***
I'll implement the functions that make use of this new data in a subsequent PR.

***

Note: @screensoftware can you take a quick look at this as well? Having to add `workDoneInTime` in a number of places that interact with the UsersDB worries me. Can you think of a better way to handle this?