### PR TITLE
removed deleteProject

### DIFF
--- a/front-end/src/data/projects.ts
+++ b/front-end/src/data/projects.ts
@@ -84,23 +84,23 @@ export async function deleteProject(projectID: ProjectID): Promise<void> {
   const project: Project = await findProjectById(projectID);
 
   // delete all the images from the images' database
-  await Promise.all(Object.entries(project.images.blocks).map(
+  Object.entries(project.images.blocks).forEach(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async ([key, value]) => {
-      await Promise.all(Object.entries(value.block.toAnnotate).map(
+      Object.entries(value.block.toAnnotate).forEach(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         async ([key, imageID]) => {
           await deleteImageFromProject(projectID, imageID);
         },
-      ));
-      await Promise.all(Object.entries(value.block.toVerify).map(
+      );
+      Object.entries(value.block.toVerify).forEach(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         async ([key, imageID]) => {
           await deleteImageFromProject(projectID, imageID);
         },
-      ));
+      );
     },
-  ));
+  );
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   await Promise.all(Object.entries(project.images.done).map(async ([key, image]) => {
     await deleteImageFromProject(projectID, image.imageId);

--- a/front-end/src/view/components/projects/index.tsx
+++ b/front-end/src/view/components/projects/index.tsx
@@ -64,10 +64,6 @@ export default function Dashboard() {
         name: 'Close',
         action: () => null,
       },
-      {
-        name: 'Delete',
-        action: deleteProject,
-      },
     ],
     annotator: [
       {

--- a/front-end/src/view/components/projects/index.tsx
+++ b/front-end/src/view/components/projects/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   useUserNotNull,
-  deleteProject,
   getProjectsOfUser,
 } from '../../../data';
 


### PR DESCRIPTION
The function `deleteProject` seems to be broken. I wanted to assign you since it seems that you're the last person to have edited it.

The error is probably due to the fact that all `deleteImageFromProject` calls modify the same project object and different calls in the same `map()` do not wait for each other. I believe converting them to conventional for loops with `await`'s inside the loop body is highly likely to solve the issue.

We should either fix the function or remove this button. You can choose as you like.